### PR TITLE
NRC and GDNS

### DIFF
--- a/Libraries/gdns.lua
+++ b/Libraries/gdns.lua
@@ -1,0 +1,56 @@
+local gert = require("GERTiClient")
+local event = require("event")
+local gdns = {}
+local mainServer = nil
+local altServer = nil
+
+local function waitForData(socket)
+    event.pull("GERTData")
+    local buf = socket:read()
+    while #buf == 0 do
+        os.sleep(0.1)
+        buf = socket:read()
+    end
+    return buf
+end
+
+function gdns.getMainServer()
+    return mainServer
+end
+
+function gdns.getAltServer()
+    return altServer
+end
+
+function gdns.setMainServer(main)
+    mainServer = main
+end
+
+function gdns.setAltServer(alt)
+    altServer = alt
+end
+
+function gdns.resolve(domain, server)
+    if not server then
+        if not mainServer and not altServer then
+            return nil, "no server defined"
+        end
+        server = mainServer or altServer
+    end
+    local socket = gert.openSocket(server)
+    if not socket then
+        if server == altServer then
+            return nil, "neither main or alt server are opened"
+        end
+        return gdns.resolve(domain, altServer)
+    end
+    socket:write(domain)
+    local data = waitForData(socket)[1]
+    if data == -1.0 then
+        return nil, ""
+    else
+        return data
+    end
+end
+
+return gdns

--- a/Programs/GDNS Server.lua
+++ b/Programs/GDNS Server.lua
@@ -1,0 +1,39 @@
+local gert = require("GERTiClient")
+local event = require("event")
+local serialize = require("serialization")
+local computer = require("computer")
+local sockets = {}
+local addresses = {}
+
+print("Address is " .. gert.getAddress())
+
+local function incoming(_, origin, id)
+  sockets[origin] = gert.openSocket(origin, true, id)
+end
+
+local function data(_, origin, id)
+  local socket = sockets[origin]
+  local rq = socket:read[1]
+  print("Request for domain " .. rq)
+  local stream = io.open("/domains.txt", "r")
+  addresses = serialize.unserialize(stream:read("*a"))
+  stream:close()
+  if addresses[rq] then
+    socket:write(addresses[rq])
+  else
+    socket:write(-1.0)
+  end
+end
+
+event.listen("GERTConnectionID", incoming)
+event.listen("GERTData", data)
+
+if false then -- optional, blocking DNS, to get better track of info
+while true do
+  local id = event.pull()
+  if id == "interrupted" then
+    event.ignore("GERTConnectionID", incoming)
+    event.ignore("GERTData", data)
+  end
+end
+end

--- a/Programs/GDNS Server.lua
+++ b/Programs/GDNS Server.lua
@@ -13,7 +13,7 @@ end
 
 local function data(_, origin, id)
   local socket = sockets[origin]
-  local rq = socket:read[1]
+  local rq = socket:read()[1]
   print("Request for domain " .. rq)
   local stream = io.open("/domains.txt", "r")
   addresses = serialize.unserialize(stream:read("*a"))

--- a/Programs/NRC Client.lua
+++ b/Programs/NRC Client.lua
@@ -1,0 +1,92 @@
+local GERT = require("GERTiClient")
+local event = require("event")
+local term = require("term")
+local component = require("component")
+local shell = require("shell")
+local gpu = component.gpu
+local width, height = gpu.getResolution()
+local name = "zenith391"
+local channel = "none"
+local args, ops = shell.parse(...)
+
+if #args < 1 then
+  io.stderr:write("Usage: nrc [server]\n")
+  return
+end
+
+local server = args[1]
+if tonumber(server) == nil then
+  local ok = pcall(function()
+    server = require("GDNS").resolve(server)
+    if server == false then
+      io.stderr:write("Invalid domain: " .. args[1] .. "\n")
+      return
+    end
+  end)
+  if not ok then
+    io.stderr:write("Please install GDNS to resolve domains")
+  end
+end
+
+local socket = nil
+local y = 2
+
+local socketOpened(_, origin, id)
+  print(origin)
+  socket:write("USERNAME " .. name)
+end
+
+local function message(_, origin, id)
+  os.sleep(0.1)
+  local tab = socket:read()
+  for _, data in pairs(tab) do
+    local _, row = term.getCursor()
+    gpu.setBackground(0x000000)
+    gpu.setForeground(0xFFFFFF)
+    if y == 40 then
+      gpu.fill(1, 1, 160, 20, " ")
+      gpu.set(1, 1, "Channel: " .. channel)
+      gpu.copy(1, 20, 160, 20, 0, -19)
+      gpu.fill(1, 20, 160, 20, " ")
+      y = 20
+    end
+    gpu.set(1, y, data)
+    y = y + 1
+  end
+end
+
+event.listen("GERTConnectionID", socketOpened)
+event.listen("GERTData", message)
+socket = GERT.openSocket(tonumber(server), true, 80)
+gpu.fill(1, 1, 160, 50, " ")
+gpu.set(1, 1, "Channel: none")
+while true do
+  gpu.setBackground(0x000000)
+  gpu.fill(1, 48, 160, 2, " ")
+  term.setCursor(1, 49)
+  io.write(">")
+  local msg = term.read()
+  if type(msg) ~= "boolean" then
+    msg = msg:sub(1, msg:len()-1)
+  end
+  if type(msg) == "boolean" or msg == "/quit" then
+    socket:close()
+    event.ignore("GERTConnectionID", socketOpened)
+    event.ignore("GERTData", message)
+    break
+  end
+  if msg:len() > 0 then
+    if msg:sub(1, 1) == "/" and msg:len() > 5 and msg:sub(1, 5) == "/join" then
+      if msg:sub(1, 5) == "/join" then
+        local cha = msg:sub(7, msg:len())
+        socket:write("CHANNEL " .. cha)
+        channel = cha
+        gpu.set(1, 1, "Channel: #" .. channe)
+      end
+    else
+      socket:write("SAY " .. msg)
+    end
+  end
+end
+
+gpu.setResolution(width, height)

--- a/Programs/NRC Server.lua
+++ b/Programs/NRC Server.lua
@@ -1,0 +1,46 @@
+local GERT = require("GERTiClient")
+local event = require("event")
+local component = require("component")
+local clients = {}
+local channels = {
+}
+local motd = {
+"Test Server",
+"Configure at your likings"
+}
+
+function string.split(str)
+  local t={}
+  for part in string.gmatch(str, "([^%s]+)") do table.insert(t, part) end
+  return t
+end
+
+local function incoming(_, origin, id)
+  clients[origin] = {}
+  local sock = GERT.openSocket(origin, true, id)
+  clients[origin] = {
+    username = nil,
+    channel = nil,
+    socket = sock
+  }
+  for _, v in pairs(motd) do
+    sock:write(v)
+  end
+end
+
+local function data(_, origin, id)
+  local cl = clients[origin]
+  local data = cl.socket:read()[1]
+  local split = string.split(data)
+  pcall(function() -- to avoid some little tweakers to crash NRC server with bad syntax
+    if split[1] == "USERNAME" then
+      cl.username = split[2]
+    end
+    if split[1] == "CHANNEL" then
+      
+    end
+  end)
+end
+
+event.listen("GERTConnectionID", data)
+event.listen("GERTData", data)

--- a/Programs/NRC Server.lua
+++ b/Programs/NRC Server.lua
@@ -3,6 +3,10 @@ local event = require("event")
 local component = require("component")
 local clients = {}
 local channels = {
+  ["general"] = {
+    clients = {},
+    messages = {"<Server> something"}
+  }
 }
 local motd = {
 "Test Server",
@@ -33,11 +37,16 @@ local function data(_, origin, id)
   local data = cl.socket:read()[1]
   local split = string.split(data)
   pcall(function() -- to avoid some little tweakers to crash NRC server with bad syntax
-    if split[1] == "USERNAME" then
-      cl.username = split[2]
+    if split[1] == "USERNAME" and not cl.username then
+        cl.username = split[2]
     end
     if split[1] == "CHANNEL" then
-      
+        if cl.channel ~= nil then
+          channels[cl.channel].clients[origin] = nil
+        end
+    end
+    if split[1] == "SAY" then
+        
     end
   end)
 end

--- a/Programs/NRC Server.lua
+++ b/Programs/NRC Server.lua
@@ -1,25 +1,52 @@
 local GERT = require("GERTiClient")
 local event = require("event")
 local component = require("component")
+local programArgs, ops = require("shell").parse(...)
+local doLoop = (ops.async or ops.a) == true
+local silent = ops.silent or ops.s
+local doLog = not silent
 local clients = {}
-local channels = {
+local channels = { -- example channels
   ["general"] = {
     clients = {},
-    messages = {"<Server> something"}
+    messages = {"<Server> Server: OK!"}
+  },
+  ["gert"] = {
+    clients = {},
+    messages = {"<Server> This channel is about GERTi/GERTe"}
+  },
+  ["global-empire"] = {
+    clients = {},
+    messages = {"<Server> Here it's everything about GlobalEmpire"}
   }
 }
 local motd = {
-"Test Server",
-"Configure at your likings"
+"-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-",
+"Welcome to NRC Server.",
+"You are connected to address " .. GERT.getAddress(),
+"The word of today is 'setup'",
+"Change this MOTD as much as you like",
+"=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
 }
 
-function string.split(str)
+function string.split(str, sep)
+  if sep == nil then
+    sep = "%s"
+  end
   local t={}
-  for part in string.gmatch(str, "([^%s]+)") do table.insert(t, part) end
+  for part in string.gmatch(str, "([^"..sep.."]+)") do
+    table.insert(t, part)
+  end
   return t
 end
 
 local function incoming(_, origin, id)
+  if doLog then print("Connection attempted from " .. origin) end
+  if clients[origin] then
+    if doLog then print("Cancelled connection from " .. origin) end
+    return
+  end
+  if doLog then print("Connection from " .. origin .. " accepted") end
   clients[origin] = {}
   local sock = GERT.openSocket(origin, true, id)
   clients[origin] = {
@@ -27,29 +54,112 @@ local function incoming(_, origin, id)
     channel = nil,
     socket = sock
   }
-  for _, v in pairs(motd) do
+  for k, v in pairs(motd) do
     sock:write(v)
   end
 end
 
 local function data(_, origin, id)
+  os.sleep(0.1)
   local cl = clients[origin]
-  local data = cl.socket:read()[1]
+  local sock = cl.socket
+  local data = sock:read()[1]
   local split = string.split(data)
-  pcall(function() -- to avoid some little tweakers to crash NRC server with bad syntax
-    if split[1] == "USERNAME" and not cl.username then
-        cl.username = split[2]
-    end
-    if split[1] == "CHANNEL" then
-        if cl.channel ~= nil then
+  local ok, err = pcall(function()
+    if not cl.username then
+      if split[1] == "USERNAME" then
+        cl.username = data:sub(10, data:len())
+        if doLog then print(origin .. " connected as " .. cl.username) end
+      end
+    else
+      if split[1] == "SAY" and cl.channel then
+        if not channels[cl.channel] then
+          channels[cl.channel] = {
+            messages = {"<Server> Channel didn't existed before, created right now by " .. cl.username},
+            clients = {}
+          }
+        end
+        local amsg = data:sub(5, data:len())
+        if amsg == "/list" then
+          cl.socket:write("Channel List:")
+          for k, ch in pairs(channels) do
+            cl.socket:write("  - " .. k)
+            cl.socket:write("    - Players connected:")
+            for _, cli in pairs(ch.clients) do
+              cl.socket:write("      - " .. cli.username)
+            end
+          end
+          return
+        end
+        local msg = "<" .. cl.username .. "> " .. amsg
+        if doLog then print("#" .. cl.channel .. " " .. msg) end
+        table.insert(channels[cl.channel].messages, msg)
+        if #channels[cl.channel].messages > 30 then -- not more than 30 messages in history
+          table.remove(channels[cl.channel].messages, 1)
+        end
+        for _, client in pairs(channels[cl.channel].clients) do
+          client.socket:write(msg)
+        end
+      end
+      if split[1] == "CHANNEL" then
+        if cl.channel then
           channels[cl.channel].clients[origin] = nil
         end
-    end
-    if split[1] == "SAY" then
-        
+        cl.channel = split[2]
+        if not channels[cl.channel] then
+          channels[cl.channel] = {
+            messages = {"<Server> Newly created channel"},
+            clients = {}
+          }
+        end
+        channels[cl.channel].clients[origin] = cl
+        -- Send history
+        cl.socket:write("History of channel " .. cl.channel)
+        for _, msg in pairs(channels[cl.channel].messages) do
+          cl.socket:write(msg)
+        end
+      end
     end
   end)
+  if not ok then
+    print(err)
+  end
 end
 
-event.listen("GERTConnectionID", data)
+local function close(_, origin, _, id)
+  if clients[origin].closing then return end
+  if clients[origin].username then
+    if doLog then print(clients[origin].username .. " disconnected") end 
+  else
+    if doLog then print(origin .. " disconnected") end
+  end
+  clients[origin].closing = true
+  clients[origin].socket:close()
+  clients[origin] = nil
+end
+
 event.listen("GERTData", data)
+event.listen("GERTConnectionClose", close)
+event.listen("GERTConnectionID", incoming)
+
+print("NRC Server v1.0 (for GERTi 1.1)")
+print("Server Address: " .. GERT.getAddress())
+
+if doLoop then
+  print("Use Ctrl+C to quit")
+  while true do
+    local id = event.pull()
+    if id == "interrupted" then
+      break
+    end
+  end
+  
+  for _, v in pairs(clients) do
+    v.socket:close()
+  end
+  event.ignore("GERTData", data)
+  event.ignore("GERTConnectionClose", close)
+  event.ignore("GERTConnectionID", incoming)
+else
+  print("Launched in background")
+end


### PR DESCRIPTION
I would like to merge my programs.
NRC is like OpenChat but, with channels and server commands.

GDNS, like its name suggests, is a DNS-like thing for GERT. The protocol is (too much) simple. For the server, domains are listed as a Lua table in `/domains.txt` like this:
```
{
  "mycustomdomain.com" = 0.1,
  "outsideof.this.server" = "0045.2515:0000.0002",
}
```
On the other hand, GDNS client library needs a main or alt server (it can check both). Excluding getters/setters for main server and alt server, it provides one function: gdns.resolve(domain[, server]). Result is the address as number (GERTi address) or string (GERTe address). If an error occurs, result is nil and second result is error message.